### PR TITLE
Add `main` method to `MockSalesforceApiServer.groovy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ This will start a server on localhost that tries to respond reasonably by defaul
 MockSalesforceApiServer mockServer = new MockSalesforceApiServer(443)
 
 ```
+
+You can start the server from command line using [Exec Maven Plugin](http://www.mojohaus.org/exec-maven-plugin/):
+
+    >  mvn compile exec:java -Dexec.mainClass=com.confluex.test.salesforce.MockSalesforceApiServer -Dexec.args="443"
+     
+#### Caveats
+If you get an error like this
+
+    java.lang.reflect.InvocationTargetException
+        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+        ...    
+    Caused by: java.net.BindException: Permission denied
+
+it means that you might need specific permissions in order to bind the process to certain ports. In this case try using
+a different port or running the process with a user with sufficient permissions.

--- a/src/main/groovy/com/confluex/test/salesforce/MockSalesforceApiServer.groovy
+++ b/src/main/groovy/com/confluex/test/salesforce/MockSalesforceApiServer.groovy
@@ -27,6 +27,14 @@ class MockSalesforceApiServer {
     private MockSforceApi sforceApi
     private MockStreamingApi streamingApi
 
+    static void main(String[] args) {
+        if (args.length == 1 && args[0].isInteger()) {
+            new MockSalesforceApiServer(args[0].toInteger())
+        } else {
+            throw new IllegalArgumentException("Please pass exactly one numeric parameter for the port number")
+        }
+    }
+
     MockSalesforceApiServer(int port) {
         httpsServer = new MockHttpsServer(port)
         asyncApi = new MockAsyncApi(httpsServer)


### PR DESCRIPTION
- Added a main method to `MockSalesforceApiServer.groovy` in order to make it easier to run the server from command line
- Added respective instructions to `README.md`
